### PR TITLE
Set color of free text annotations (#24)

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -287,10 +287,11 @@ export class AnnotationFactory {
      * author : the author of the annotation
      * color : the color of the annotation in rgb. Can be of domain 0 - 255 or 0 - 1
      * */
-    createFreeTextAnnotation(page: number, rect: number[], contents: string, author: string, color: Color = { r: 1, g: 1, b: 0 }) {
+    createFreeTextAnnotation(page: number, rect: number[], contents: string, author: string, color: Color = { r: 1, g: 1, b: 1 }) {
         this.checkRect(4, rect)
         let annot: Annotation = (<any>Object).assign(this.createBaseAnnotation(page, rect, contents, author), {
             textAlignment: "right-justified",
+            color: color,
             defaultAppearance: "/Invalid_font 9 Tf"
         })
 


### PR DESCRIPTION
Sets the missing color attribute in `createFreeTextAnnotation`.
I also set the default color to white to match the color used without this patch.