### PR TITLE
Update demo example

### DIFF
--- a/examples/pdfjsExample.html
+++ b/examples/pdfjsExample.html
@@ -1,6 +1,14 @@
 <!-- index.htm -->
 <html>
         <head>
+               <style>
+                   #viewerContainer {
+                         overflow: auto;
+                         position: absolute;
+                         width: 100%;
+                         height: 100%;
+                        }
+                </style>
                 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.0.943/web/pdf_viewer.css">
                 <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.0.943/build/pdf.min.js"></script>
                 <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.0.943/web/pdf_viewer.js"></script>


### PR DESCRIPTION
Earlier, this demo was only able to annotate on page 1 as the current page number of the pdfViewer was not updating due to the position property for the dom element (viewer container ) not set accordingly.