### PR TITLE
Fix/deleteAnnotation

### DIFF
--- a/src/__tests__/annotation.test.ts
+++ b/src/__tests__/annotation.test.ts
@@ -1,4 +1,6 @@
-import { ParameterParser } from '../annotation';
+import { ParameterParser, AnnotationFactory } from '../annotation';
+import { testDocument } from './Data'
+import { AnnotationIcon } from '../annotations/text_annotation';
 
 test('testParseParameters', () => {
     let params : any = [0, [50, 50, 80, 80], "Test123", "John"]
@@ -45,4 +47,22 @@ test('testParseParameters', () => {
     expect(res.author).toBe("John")
     expect(res.color).toEqual({r: 1, g: 1, b: 0})
     expect(res.quadPoints).toEqual([100, 130, 150, 130, 100, 100, 150, 100 /*rectangle one*/, 150, 180, 200, 180, 150, 150, 200, 150 /*rectangle two*/])
+})
+test('deleteAnnotation',async ()=>{
+    let data = new Uint8Array(testDocument)
+    let factory = new AnnotationFactory(data)
+    factory.createTextAnnotation({
+        page: 0,
+        rect: [50, 50, 80, 80],
+        contents: "Pop up note",
+        author: "Max",
+        color: {r: 128, g: 128, b: 128},
+        open: false,
+        icon: AnnotationIcon.Help,
+        opacity: 0.5
+        })
+    let annotations=await factory.getAnnotations()
+    await factory.deleteAnnotation(annotations[0][2].id)
+    expect(factory.getAnnotationCount()).toEqual(0)
+    
 })

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -493,11 +493,11 @@ export class AnnotationFactory {
             // delete if it was just created but is not in the pdf document
             for (let i = 0; i < this.annotations.length; ++i) {
                 if ('string' === typeof id && this.annotations[i].id === id) {
-                    this.annotations = this.annotations.slice(i, 1)
+                    this.annotations = this.annotations = [...this.annotations.slice(0, i), ...this.annotations.slice(i+1)]
                     resolve(this.toDelete)
                     return
                 } else if (id.obj && this.annotations[i].object_id && id.obj === (<any>this.annotations[i].object_id).obj && id.generation && id.generation === (<any>this.annotations[i].object_id).generation) {
-                    this.annotations = this.annotations.slice(i, 1)
+                    this.annotations = this.annotations = [...this.annotations.slice(0, i), ...this.annotations.slice(i+1)]
                     resolve(this.toDelete)
                     return
                 }


### PR DESCRIPTION
Currently the removeAnnotation method doesn't remove the specified annotation, because slice is used like splice for removal.

This PR adds a test for deleteAnnotation and fixes the behaviour by using slice in the correct way to delete an element of the array.

References:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice
- https://stackoverflow.com/questions/11848534/remove-element-from-array-using-slice